### PR TITLE
Fix add employee flow

### DIFF
--- a/controllers/employeeController.js
+++ b/controllers/employeeController.js
@@ -17,40 +17,63 @@ const storage = multer.diskStorage({
 const upload = multer({storage: storage})
 
 const addEmployee = async (req, res) => {
-    try{
-    const {
-        name, email, employeeId, dob, gender, maritalStatus, designation, department, salary, password, role,
-    } = req.body;
+    try {
+        const {
+            name,
+            email,
+            employeeId,
+            dob,
+            gender,
+            maritalStatus,
+            designation,
+            department,
+            salary,
+            password,
+            role,
+        } = req.body;
 
-    const user = await User.findOne({email})
-    if(user){
-        return res.status(400).json({success: false, error: "User alreadly registered in emp"})
-    }
+        const userRole = role || "employee";
 
-    const hashPassword = await bcrypt.hash(password, 10)
-    const newUser = new User({
-        name, 
-        email,
-        password: hashPassword,
-        role,
-        profileImage: req.file ? req.file.filename : ""
-    })
-    const savedUser = await newUser.save()
-    const newEmployee = new Employee({
-        userId: savedUser._id, 
-        employeeId,
-        dob,
-        gender,
-        maritalStatus,
-        designation,
-        department,
-        salary
-    })
-    await newEmployee.save()
-    return res.status(200).json({success: true, message: "employee created"})
-    }catch(error){
-        console.log(error.message)
-        return res.status(500).json({success: false, error: "Server error in adding employee"})
+        const existingUser = await User.findOne({ email });
+        if (existingUser) {
+            return res
+                .status(400)
+                .json({ success: false, error: "User alreadly registered in emp" });
+        }
+
+        const existingEmployee = await Employee.findOne({ employeeId });
+        if (existingEmployee) {
+            return res
+                .status(400)
+                .json({ success: false, error: "Employee ID already exists" });
+        }
+
+        const hashPassword = await bcrypt.hash(password || "123456", 10);
+        const newUser = new User({
+            name,
+            email,
+            password: hashPassword,
+            role: userRole,
+            profileImage: req.file ? req.file.filename : "",
+        });
+        const savedUser = await newUser.save();
+        const newEmployee = new Employee({
+            userId: savedUser._id,
+            employeeId,
+            dob,
+            gender,
+            maritalStatus,
+            designation,
+            department,
+            salary,
+        });
+        await newEmployee.save();
+        return res.status(200).json({ success: true, message: "employee created" });
+    } catch (error) {
+        console.log(error.message);
+        return res
+            .status(500)
+            .json({ success: false, error: "Server error in adding employee" });
     }
 }
 

--- a/routes/employee.js
+++ b/routes/employee.js
@@ -6,6 +6,7 @@ const router = express.Router()
 
 router.get('/', authMiddleware, getEmployees)
 router.post('/add', authMiddleware, upload.single('image'), addEmployee)
+router.post('/', authMiddleware, upload.single('image'), addEmployee)
 router.get('/:id', authMiddleware, getEmployee)
 router.put('/:id', authMiddleware, updateEmployee)
 router.get('/department/:id', authMiddleware, fetchEmployeesByDepId)


### PR DESCRIPTION
## Summary
- improve addEmployee controller: default role, check duplicate employeeId, handle missing password
- support POST `/api/employee` in addition to `/add`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685dd768e8cc83218092fa6bd9167260